### PR TITLE
Added ability to wait between Lock attempts

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -34,6 +34,10 @@ func TestDBSuite(t *testing.T) {
 	suite.Run(t, new(DBSuite))
 }
 
+func (s *DBSuite) SetupSuite() {
+
+}
+
 func (s *DBSuite) SetupTest() {
 	s.mock = new(mocks.AWSDynamoer)
 	s.db = NewDatabase(DB_VALID_TABLE_NAME, DB_VALID_REGION, DB_VALID_NO_ENDPOINT, DB_VALID_DISABLE_SSL_NO)

--- a/glide.lock
+++ b/glide.lock
@@ -1,51 +1,35 @@
-hash: 409849d8da430594596e9f74459552b0d5ec33035a365024c7acf52168036c21
-updated: 2017-03-16T11:47:11.109653748Z
+hash: c8eda54028fd67096ca88a85b938c46dab40d22388184d64f9a2a7636e4e9003
+updated: 2016-05-26T14:30:42.755422873+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 695fe24acaf9afe80b0ce261d4637f42ba0b4c7d
+  version: c3505486c9bc67389575587c2154500864883384
   subpackages:
   - aws
+  - internal/endpoints
+  - internal/protocol/json/jsonutil
+  - internal/protocol/jsonrpc
+  - internal/protocol/rest
+  - internal/signer/v4
+  - service/dynamodb
   - aws/awserr
+  - aws/credentials
   - aws/awsutil
   - aws/client
   - aws/client/metadata
-  - aws/corehandlers
-  - aws/credentials
-  - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
-  - aws/defaults
-  - aws/ec2metadata
-  - aws/endpoints
   - aws/request
-  - aws/session
-  - aws/signer/v4
-  - private/protocol
-  - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
-  - private/protocol/query
-  - private/protocol/query/queryutil
-  - private/protocol/rest
-  - private/protocol/xml/xmlutil
+  - private/signer/v4
   - private/waiter
-  - service/dynamodb
-  - service/sts
-- name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
-  subpackages:
-  - spew
+  - private/protocol/json/jsonutil
+  - private/protocol/rest
 - name: github.com/go-ini/ini
-  version: c437d20015c2ab6454b7a66a13109ff0fb99e17a
+  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
+  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: c478a808a1b37e10c82f71a2172728f8742bad51
   subpackages:
   - assert
   - mock
@@ -53,4 +37,4 @@ imports:
   - suite
 - name: github.com/vaughan0/go-ini
   version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1
-testImports: []
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,23 @@
 package: github.com/zencoder/ddbsync
 import:
 - package: github.com/aws/aws-sdk-go
-  version: v1.7.9
+  version: v0.10.4
+  subpackages:
+  - aws
+  - internal/endpoints
+  - internal/protocol/json/jsonutil
+  - internal/protocol/jsonrpc
+  - internal/protocol/rest
+  - internal/signer/v4
+  - service/dynamodb
 - package: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - package: github.com/stretchr/testify
-  version: v1.1.4
+  version: c478a808a1b37e10c82f71a2172728f8742bad51
+  subpackages:
+  - assert
+  - mock
+  - require
+  - suite
 - package: github.com/vaughan0/go-ini
   version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1

--- a/lock_service_test.go
+++ b/lock_service_test.go
@@ -1,20 +1,29 @@
 package ddbsync
 
 import (
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"testing"
 )
 
 const LOCK_SERVICE_VALID_MUTEX_NAME string = "mut-test"
 const LOCK_SERVICE_VALID_MUTEX_TTL int64 = 4
 
-func TestNewLock(t *testing.T) {
+type LockServiceSuite struct {
+	suite.Suite
+}
+
+func TestLockServiceSuite(t *testing.T) {
+	suite.Run(t, new(LockServiceSuite))
+}
+
+func (s *LockServiceSuite) TestNewLock() {
 	ls := &LockService{}
 	m := ls.NewLock(LOCK_SERVICE_VALID_MUTEX_NAME, LOCK_SERVICE_VALID_MUTEX_TTL)
 
-	require.NotNil(t, ls)
-	require.NotNil(t, m)
-	require.IsType(t, &LockService{}, ls)
-	require.IsType(t, &Mutex{}, m)
-	require.Equal(t, &Mutex{Name: LOCK_SERVICE_VALID_MUTEX_NAME, TTL: LOCK_SERVICE_VALID_MUTEX_TTL}, m)
+	assert.NotNil(s.T(), ls)
+	assert.NotNil(s.T(), m)
+	assert.IsType(s.T(), &LockService{}, ls)
+	assert.IsType(s.T(), &Mutex{}, m)
+	assert.Equal(s.T(), &Mutex{Name: LOCK_SERVICE_VALID_MUTEX_NAME, TTL: LOCK_SERVICE_VALID_MUTEX_TTL}, m)
 }

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -4,109 +4,72 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/zencoder/ddbsync/mocks"
 	"github.com/zencoder/ddbsync/models"
-	"time"
 )
 
-const (
-	VALID_MUTEX_NAME    string = "mut-test"
-	VALID_MUTEX_TTL     int64  = 4
-	VALID_MUTEX_CREATED int64  = 1424385592
-)
+const VALID_MUTEX_NAME string = "mut-test"
+const VALID_MUTEX_TTL int64 = 4
+const VALID_MUTEX_CREATED int64 = 1424385592
 
-var lockHeldErr = awserr.New(
-	dynamodb.ErrCodeConditionalCheckFailedException,
-	"Conditional Check Failed",
-	errors.New("Conditional Check Failed"),
-)
-
-var dynamoInternalErr = awserr.New(
-	dynamodb.ErrCodeInternalServerError,
-	"Dynamo Internal Server Error",
-	errors.New("Dynamo Internal Server Error"),
-)
-
-func TestNew(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
-
-	require.Equal(t, VALID_MUTEX_NAME, underTest.Name)
-	require.Equal(t, VALID_MUTEX_TTL, underTest.TTL)
+type MutexSuite struct {
+	suite.Suite
+	mock *mocks.DBer
 }
 
-func TestLock(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+func TestMutexSuite(t *testing.T) {
+	suite.Run(t, new(MutexSuite))
+}
 
-	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Return(nil)
-	db.On("Get", VALID_MUTEX_NAME).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
-	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
+func (s *MutexSuite) SetupSuite() {
+
+}
+
+func (s *MutexSuite) SetupTest() {
+	s.mock = new(mocks.DBer)
+}
+
+func (s *MutexSuite) TestNew() {
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
+
+	assert.Equal(s.T(), VALID_MUTEX_NAME, underTest.Name)
+	assert.Equal(s.T(), VALID_MUTEX_TTL, underTest.TTL)
+}
+
+func (s *MutexSuite) TestLock() {
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
+
+	s.mock.On("Put", mock.AnythingOfType("string"), mock.AnythingOfType("int64")).Return(nil)
+	s.mock.On("Get", mock.AnythingOfType("string")).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
+	s.mock.On("Delete", mock.AnythingOfType("string")).Return(nil)
 
 	underTest.Lock()
-	db.AssertExpectations(t)
 }
 
-func TestLockWaitsBeforeRetrying(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
-	underTest.LockReattemptWait = 300 * time.Millisecond
+func (s *MutexSuite) TestUnlock() {
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
 
-	db.On("Get", VALID_MUTEX_NAME).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
-	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
-	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(lockHeldErr)
-	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(dynamoInternalErr)
-	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(errors.New("Dynamo Glitch"))
-	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(nil)
-
-	before := time.Now()
-	underTest.Lock()
-	duration := time.Since(before)
-
-	db.AssertExpectations(t)
-	require.True(t, duration > (900*time.Millisecond), "Expected to have waited at least 0.3 secs between each retry, total wait time: %s", duration)
-}
-
-func TestUnlock(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
-
-	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
+	s.mock.On("Delete", mock.AnythingOfType("string")).Return(nil)
 
 	underTest.Unlock()
 }
 
-func TestUnlockGivesUpAfterThreeAttempts(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+func (s *MutexSuite) TestPruneExpired() {
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
 
-	db.On("Delete", VALID_MUTEX_NAME).Times(3).Return(errors.New("DynamoDB is down!"))
-
-	underTest.Unlock()
-	db.AssertExpectations(t)
-}
-
-func TestPruneExpired(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
-
-	db.On("Get", VALID_MUTEX_NAME).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
-	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
+	s.mock.On("Get", mock.AnythingOfType("string")).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
+	s.mock.On("Delete", mock.AnythingOfType("string")).Return(nil)
 
 	underTest.PruneExpired()
-	db.AssertExpectations(t)
 }
 
-func TestPruneExpiredError(t *testing.T) {
-	db := new(mocks.DBer)
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+func (s *MutexSuite) TestPruneExpiredError() {
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
 
-	db.On("Get", VALID_MUTEX_NAME).Return((*models.Item)(nil), errors.New("Get Error"))
+	s.mock.On("Get", mock.AnythingOfType("string")).Return((*models.Item)(nil), errors.New("Get Error"))
 
 	underTest.PruneExpired()
-	db.AssertExpectations(t)
 }


### PR DESCRIPTION
This should stop clients from hammering Dynamo while waiting for a lock.

Also:

* Now only attempt to release a lock 3 times
* Tidied up the tests and moved away from Testify Suite