### PR TITLE
Added ability to wait between Lock attempts

### DIFF
--- a/db.go
+++ b/db.go
@@ -45,18 +45,17 @@ type AWSDynamoer interface {
 
 func (db *database) Put(name string, created int64) error {
 	i := map[string]*dynamodb.AttributeValue{
-		"Name": &dynamodb.AttributeValue{
+		"Name": {
 			S: aws.String(name),
 		},
-		"Created": &dynamodb.AttributeValue{
+		"Created": {
 			N: aws.String(strconv.FormatInt(created, 10)),
 		},
 	}
 
-	no := false
 	e := map[string]*dynamodb.ExpectedAttributeValue{
-		"Name": &dynamodb.ExpectedAttributeValue{
-			Exists: &no,
+		"Name": {
+			Exists: aws.Bool(false),
 		},
 	}
 
@@ -65,29 +64,25 @@ func (db *database) Put(name string, created int64) error {
 		Item:      i,
 		Expected:  e,
 	}
-	_, err := db.client.PutItem(pit)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	_, err := db.client.PutItem(pit)
+	return err
 }
 
 func (db *database) Get(name string) (*models.Item, error) {
 	kc := map[string]*dynamodb.Condition{
-		"Name": &dynamodb.Condition{
+		"Name": {
 			AttributeValueList: []*dynamodb.AttributeValue{
-				&dynamodb.AttributeValue{
+				{
 					S: aws.String(name),
 				},
 			},
 			ComparisonOperator: aws.String("EQ"),
 		},
 	}
-	yes := true
 	qi := &dynamodb.QueryInput{
 		TableName:       aws.String(db.tableName),
-		ConsistentRead:  &yes,
+		ConsistentRead:  aws.Bool(true),
 		Select:          aws.String("SPECIFIC_ATTRIBUTES"),
 		AttributesToGet: []*string{aws.String("Name"), aws.String("Created")},
 		KeyConditions:   kc,
@@ -101,9 +96,9 @@ func (db *database) Get(name string) (*models.Item, error) {
 	// Make sure that no or 1 item is returned from DynamoDB
 	if qo.Count != nil {
 		if *qo.Count == 0 {
-			return nil, errors.New(fmt.Sprintf("No item for Name, %s", name))
+			return nil, fmt.Errorf("No item for Name, %s", name)
 		} else if *qo.Count > 1 {
-			return nil, errors.New(fmt.Sprintf("Expected only 1 item returned from Dynamo, got %d", *qo.Count))
+			return nil, fmt.Errorf("Expected only 1 item returned from Dynamo, got %d", *qo.Count)
 		}
 	} else {
 		return nil, errors.New("Count not returned")
@@ -135,7 +130,7 @@ func (db *database) Get(name string) (*models.Item, error) {
 
 func (db *database) Delete(name string) error {
 	k := map[string]*dynamodb.AttributeValue{
-		"Name": &dynamodb.AttributeValue{
+		"Name": {
 			S: aws.String(name),
 		},
 	}
@@ -144,9 +139,5 @@ func (db *database) Delete(name string) error {
 		Key:       k,
 	}
 	_, err := db.client.DeleteItem(dii)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/db_test.go
+++ b/db_test.go
@@ -34,10 +34,6 @@ func TestDBSuite(t *testing.T) {
 	suite.Run(t, new(DBSuite))
 }
 
-func (s *DBSuite) SetupSuite() {
-
-}
-
 func (s *DBSuite) SetupTest() {
 	s.mock = new(mocks.AWSDynamoer)
 	s.db = NewDatabase(DB_VALID_TABLE_NAME, DB_VALID_REGION, DB_VALID_NO_ENDPOINT, DB_VALID_DISABLE_SSL_NO)

--- a/glide.lock
+++ b/glide.lock
@@ -1,35 +1,51 @@
-hash: c8eda54028fd67096ca88a85b938c46dab40d22388184d64f9a2a7636e4e9003
-updated: 2016-05-26T14:30:42.755422873+01:00
+hash: 409849d8da430594596e9f74459552b0d5ec33035a365024c7acf52168036c21
+updated: 2017-03-16T11:47:11.109653748Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: c3505486c9bc67389575587c2154500864883384
+  version: 695fe24acaf9afe80b0ce261d4637f42ba0b4c7d
   subpackages:
   - aws
-  - internal/endpoints
-  - internal/protocol/json/jsonutil
-  - internal/protocol/jsonrpc
-  - internal/protocol/rest
-  - internal/signer/v4
-  - service/dynamodb
   - aws/awserr
-  - aws/credentials
   - aws/awsutil
   - aws/client
   - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
   - aws/request
-  - private/protocol/jsonrpc
-  - private/signer/v4
-  - private/waiter
+  - aws/session
+  - aws/signer/v4
+  - private/protocol
   - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
   - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/dynamodb
+  - service/sts
+- name: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  subpackages:
+  - spew
 - name: github.com/go-ini/ini
-  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
+  version: c437d20015c2ab6454b7a66a13109ff0fb99e17a
 - name: github.com/jmespath/go-jmespath
-  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: c478a808a1b37e10c82f71a2172728f8742bad51
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - mock
@@ -37,4 +53,4 @@ imports:
   - suite
 - name: github.com/vaughan0/go-ini
   version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,23 +1,10 @@
 package: github.com/zencoder/ddbsync
 import:
 - package: github.com/aws/aws-sdk-go
-  version: v0.10.4
-  subpackages:
-  - aws
-  - internal/endpoints
-  - internal/protocol/json/jsonutil
-  - internal/protocol/jsonrpc
-  - internal/protocol/rest
-  - internal/signer/v4
-  - service/dynamodb
+  version: v1.7.9
 - package: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - package: github.com/stretchr/testify
-  version: c478a808a1b37e10c82f71a2172728f8742bad51
-  subpackages:
-  - assert
-  - mock
-  - require
-  - suite
+  version: v1.1.4
 - package: github.com/vaughan0/go-ini
   version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1

--- a/lock_service.go
+++ b/lock_service.go
@@ -2,10 +2,11 @@ package ddbsync
 
 import (
 	"sync"
+	"time"
 )
 
 type LockServicer interface {
-	NewLock(string, int64) sync.Locker
+	NewLock(string, int64, time.Duration) sync.Locker
 }
 
 type LockService struct {
@@ -21,6 +22,6 @@ func NewLockService(tableName string, region string, endpoint string, disableSSL
 }
 
 // Create a new Lock/Mutex with a particular key and timeout
-func (l *LockService) NewLock(name string, ttl int64) sync.Locker {
-	return NewMutex(name, ttl, l.db)
+func (l *LockService) NewLock(name string, ttl int64, lockReattemptWait time.Duration) sync.Locker {
+	return NewMutex(name, ttl, l.db, lockReattemptWait)
 }

--- a/lock_service_test.go
+++ b/lock_service_test.go
@@ -1,29 +1,20 @@
 package ddbsync
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 const LOCK_SERVICE_VALID_MUTEX_NAME string = "mut-test"
 const LOCK_SERVICE_VALID_MUTEX_TTL int64 = 4
 
-type LockServiceSuite struct {
-	suite.Suite
-}
-
-func TestLockServiceSuite(t *testing.T) {
-	suite.Run(t, new(LockServiceSuite))
-}
-
-func (s *LockServiceSuite) TestNewLock() {
+func TestNewLock(t *testing.T) {
 	ls := &LockService{}
 	m := ls.NewLock(LOCK_SERVICE_VALID_MUTEX_NAME, LOCK_SERVICE_VALID_MUTEX_TTL)
 
-	assert.NotNil(s.T(), ls)
-	assert.NotNil(s.T(), m)
-	assert.IsType(s.T(), &LockService{}, ls)
-	assert.IsType(s.T(), &Mutex{}, m)
-	assert.Equal(s.T(), &Mutex{Name: LOCK_SERVICE_VALID_MUTEX_NAME, TTL: LOCK_SERVICE_VALID_MUTEX_TTL}, m)
+	require.NotNil(t, ls)
+	require.NotNil(t, m)
+	require.IsType(t, &LockService{}, ls)
+	require.IsType(t, &Mutex{}, m)
+	require.Equal(t, &Mutex{Name: LOCK_SERVICE_VALID_MUTEX_NAME, TTL: LOCK_SERVICE_VALID_MUTEX_TTL}, m)
 }

--- a/lock_service_test.go
+++ b/lock_service_test.go
@@ -3,18 +3,20 @@ package ddbsync
 import (
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 const LOCK_SERVICE_VALID_MUTEX_NAME string = "mut-test"
 const LOCK_SERVICE_VALID_MUTEX_TTL int64 = 4
+const LOCK_SERVICE_VALID_MUTEX_RETRY_WAIT time.Duration = 5 * time.Second
 
 func TestNewLock(t *testing.T) {
 	ls := &LockService{}
-	m := ls.NewLock(LOCK_SERVICE_VALID_MUTEX_NAME, LOCK_SERVICE_VALID_MUTEX_TTL)
+	m := ls.NewLock(LOCK_SERVICE_VALID_MUTEX_NAME, LOCK_SERVICE_VALID_MUTEX_TTL, LOCK_SERVICE_VALID_MUTEX_RETRY_WAIT)
 
 	require.NotNil(t, ls)
 	require.NotNil(t, m)
 	require.IsType(t, &LockService{}, ls)
 	require.IsType(t, &Mutex{}, m)
-	require.Equal(t, &Mutex{Name: LOCK_SERVICE_VALID_MUTEX_NAME, TTL: LOCK_SERVICE_VALID_MUTEX_TTL}, m)
+	require.Equal(t, &Mutex{Name: LOCK_SERVICE_VALID_MUTEX_NAME, TTL: LOCK_SERVICE_VALID_MUTEX_TTL, LockReattemptWait: LOCK_SERVICE_VALID_MUTEX_RETRY_WAIT}, m)
 }

--- a/mocks/LockServicer.go
+++ b/mocks/LockServicer.go
@@ -3,18 +3,19 @@ package mocks
 import "github.com/stretchr/testify/mock"
 
 import "sync"
+import "time"
 
 type LockServicer struct {
 	mock.Mock
 }
 
-// NewLock provides a mock function with given fields: _a0, _a1
-func (_m *LockServicer) NewLock(_a0 string, _a1 int64) sync.Locker {
-	ret := _m.Called(_a0, _a1)
+// NewLock provides a mock function with given fields: _a0, _a1, _a2
+func (_m *LockServicer) NewLock(_a0 string, _a1 int64, _a2 time.Duration) sync.Locker {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 sync.Locker
-	if rf, ok := ret.Get(0).(func(string, int64) sync.Locker); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(string, int64, time.Duration) sync.Locker); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		r0 = ret.Get(0).(sync.Locker)
 	}

--- a/mutex.go
+++ b/mutex.go
@@ -12,14 +12,18 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // A Mutex is a mutual exclusion lock.
 // Mutexes can be created as part of other structures.
 type Mutex struct {
-	Name string
-	TTL  int64
-	db   DBer
+	Name              string
+	TTL               int64
+	LockReattemptWait time.Duration
+	db                DBer
 }
 
 var _ sync.Locker = (*Mutex)(nil) // Forces compile time checking of the interface
@@ -43,16 +47,32 @@ func (m *Mutex) Lock() {
 		if err == nil {
 			return
 		}
+
+		// Log the error if it's not one we expect to see
+		if awsErr, ok := err.(awserr.Error); ok {
+			switch awsErr.Code() {
+			case dynamodb.ErrCodeConditionalCheckFailedException: // Something already holds the mutex
+			default:
+				log.Printf("Lock. AWS error: %v", awsErr.Message())
+			}
+		} else {
+			log.Printf("Lock. Error: %v", err)
+		}
+
+		time.Sleep(m.LockReattemptWait)
 	}
 }
 
 // Unlock will delete an item in a DynamoDB table.
+// If for some reason we can't (Dynamo is down / TTL of lock expired and something else deleted it) then
+// we give up after a few attempts and let the TTL catch it (if it hasn't already).
 func (m *Mutex) Unlock() {
-	for {
+	for i := 0; i < 3; i++ {
 		err := m.db.Delete(m.Name)
 		if err == nil {
 			return
 		}
+		log.Printf("Unlock. Error: %v", err)
 	}
 }
 

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -4,72 +4,109 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 	"github.com/zencoder/ddbsync/mocks"
 	"github.com/zencoder/ddbsync/models"
+	"time"
 )
 
-const VALID_MUTEX_NAME string = "mut-test"
-const VALID_MUTEX_TTL int64 = 4
-const VALID_MUTEX_CREATED int64 = 1424385592
+const (
+	VALID_MUTEX_NAME    string = "mut-test"
+	VALID_MUTEX_TTL     int64  = 4
+	VALID_MUTEX_CREATED int64  = 1424385592
+)
 
-type MutexSuite struct {
-	suite.Suite
-	mock *mocks.DBer
+var lockHeldErr = awserr.New(
+	dynamodb.ErrCodeConditionalCheckFailedException,
+	"Conditional Check Failed",
+	errors.New("Conditional Check Failed"),
+)
+
+var dynamoInternalErr = awserr.New(
+	dynamodb.ErrCodeInternalServerError,
+	"Dynamo Internal Server Error",
+	errors.New("Dynamo Internal Server Error"),
+)
+
+func TestNew(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+
+	require.Equal(t, VALID_MUTEX_NAME, underTest.Name)
+	require.Equal(t, VALID_MUTEX_TTL, underTest.TTL)
 }
 
-func TestMutexSuite(t *testing.T) {
-	suite.Run(t, new(MutexSuite))
-}
+func TestLock(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
 
-func (s *MutexSuite) SetupSuite() {
-
-}
-
-func (s *MutexSuite) SetupTest() {
-	s.mock = new(mocks.DBer)
-}
-
-func (s *MutexSuite) TestNew() {
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
-
-	assert.Equal(s.T(), VALID_MUTEX_NAME, underTest.Name)
-	assert.Equal(s.T(), VALID_MUTEX_TTL, underTest.TTL)
-}
-
-func (s *MutexSuite) TestLock() {
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
-
-	s.mock.On("Put", mock.AnythingOfType("string"), mock.AnythingOfType("int64")).Return(nil)
-	s.mock.On("Get", mock.AnythingOfType("string")).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
-	s.mock.On("Delete", mock.AnythingOfType("string")).Return(nil)
+	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Return(nil)
+	db.On("Get", VALID_MUTEX_NAME).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
+	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
 
 	underTest.Lock()
+	db.AssertExpectations(t)
 }
 
-func (s *MutexSuite) TestUnlock() {
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
+func TestLockWaitsBeforeRetrying(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+	underTest.LockReattemptWait = 300 * time.Millisecond
 
-	s.mock.On("Delete", mock.AnythingOfType("string")).Return(nil)
+	db.On("Get", VALID_MUTEX_NAME).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
+	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
+	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(lockHeldErr)
+	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(dynamoInternalErr)
+	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(errors.New("Dynamo Glitch"))
+	db.On("Put", VALID_MUTEX_NAME, mock.AnythingOfType("int64")).Once().Return(nil)
+
+	before := time.Now()
+	underTest.Lock()
+	duration := time.Since(before)
+
+	db.AssertExpectations(t)
+	require.True(t, duration > (900*time.Millisecond), "Expected to have waited at least 0.3 secs between each retry, total wait time: %s", duration)
+}
+
+func TestUnlock(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+
+	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
 
 	underTest.Unlock()
 }
 
-func (s *MutexSuite) TestPruneExpired() {
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
+func TestUnlockGivesUpAfterThreeAttempts(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
 
-	s.mock.On("Get", mock.AnythingOfType("string")).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
-	s.mock.On("Delete", mock.AnythingOfType("string")).Return(nil)
+	db.On("Delete", VALID_MUTEX_NAME).Times(3).Return(errors.New("DynamoDB is down!"))
 
-	underTest.PruneExpired()
+	underTest.Unlock()
+	db.AssertExpectations(t)
 }
 
-func (s *MutexSuite) TestPruneExpiredError() {
-	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, s.mock)
+func TestPruneExpired(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
 
-	s.mock.On("Get", mock.AnythingOfType("string")).Return((*models.Item)(nil), errors.New("Get Error"))
+	db.On("Get", VALID_MUTEX_NAME).Return(&models.Item{Name: VALID_MUTEX_NAME, Created: VALID_MUTEX_CREATED}, nil)
+	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
 
 	underTest.PruneExpired()
+	db.AssertExpectations(t)
+}
+
+func TestPruneExpiredError(t *testing.T) {
+	db := new(mocks.DBer)
+	underTest := NewMutex(VALID_MUTEX_NAME, VALID_MUTEX_TTL, db)
+
+	db.On("Get", VALID_MUTEX_NAME).Return((*models.Item)(nil), errors.New("Get Error"))
+
+	underTest.PruneExpired()
+	db.AssertExpectations(t)
 }

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -78,6 +78,7 @@ func TestUnlock(t *testing.T) {
 	db.On("Delete", VALID_MUTEX_NAME).Return(nil)
 
 	underTest.Unlock()
+	db.AssertExpectations(t)
 }
 
 func TestUnlockGivesUpAfterThreeAttempts(t *testing.T) {


### PR DESCRIPTION
This should stop clients from hammering Dynamo while waiting for a lock.

Also:

* Now only attempt to release a lock 3 times
* Tidied up the tests and moved away from Testify Suite